### PR TITLE
fix(refreshPeerConnections()): Adding peer connection preference

### DIFF
--- a/lib/use-cases/peer-use-cases.js
+++ b/lib/use-cases/peer-use-cases.js
@@ -375,84 +375,30 @@ class PeerUseCases {
           continue
         }
 
-        // Try a direct connection with the peer by going through
-        // the multiaddrs in the announcement object.
-        const filteredMultiaddrs = this.utils.filterMultiaddrs(peerData.data.ipfsMultiaddrs)
-        this.adapters.log.statusLog(1, 'filteredMultiaddrs: ', filteredMultiaddrs)
+        // Skip direct connection if the node has a preference for a circuit
+        // relay connection.
+        const connectPref = peerData.data.ipfsConnectPref
+        if (connectPref !== 'cr') {
+          // Try a direct connection with the peer by going through
+          // the multiaddrs in the announcement object.
+          const filteredMultiaddrs = this.utils.filterMultiaddrs(peerData.data.ipfsMultiaddrs)
+          this.adapters.log.statusLog(1, 'filteredMultiaddrs: ', filteredMultiaddrs)
 
-        for (let j = 0; j < filteredMultiaddrs.length; j++) {
-          const multiaddr = filteredMultiaddrs[j]
-          this.adapters.log.statusLog(1,
-            `Trying a direct connecto to peer ${thisPeer} with this multiaddr: ${multiaddr}.`
-          )
-
-          // Attempt to connect to the node through a circuit relay.
-          connected = await this.adapters.ipfs.connectToPeer({ multiaddr })
-          // console.log('direct connection connected: ', connected)
-
-          // If the connection was successful, break out of the relay loop.
-          // Otherwise try to connect through the next relay.
-          if (connected.success) {
+          for (let j = 0; j < filteredMultiaddrs.length; j++) {
+            const multiaddr = filteredMultiaddrs[j]
             this.adapters.log.statusLog(1,
-              `Successfully connected to peer ${thisPeer} through direct connection: ${multiaddr}.`
+              `Trying a direct connecto to peer ${thisPeer} with this multiaddr: ${multiaddr}.`
             )
-
-            // Add the connection multiaddr for this peer to the thisNode object.
-            this.updatePeerConnectionInfo({ thisPeer })
-
-            // Add the connection multiaddr to the peer, so that we can see
-            // exactly how we're connected to the peer.
-            // const thisPeerData = this.thisNode.peerData.filter(x => x.from === thisPeer)
-            // thisPeerData[0].data.connectionAddr = multiaddr
-            // peerData.data.connectionAddr = multiaddr
-
-            // Break out of the loop once we've made a successful connection.
-            break
-          } else {
-            this.adapters.log.statusLog(1,
-              `Failed to connect to peer ${thisPeer} through direct connection: ${multiaddr}. Reason: ${connected.details}`
-            )
-          }
-        }
-
-        if (connected.success) {
-          continue
-        }
-
-        // Sort the Circuit Relays by the average of the aboutLatency
-        // array. Connect to peers through the Relays with the lowest latencies
-        // first.
-        const sortedRelays = this.relayUseCases.sortRelays(relays)
-        // console.log(`sortedRelays: ${JSON.stringify(sortedRelays, null, 2)}`)
-
-        // Loop through each known circuit relay and attempt to connect to the
-        // peer through a relay.
-        for (let j = 0; j < sortedRelays.length; j++) {
-          const thisRelay = sortedRelays[j]
-          // console.log(`thisRelay: ${JSON.stringify(thisRelay, null, 2)}`)
-
-          // Generate a multiaddr for connecting to the peer through a circuit relay.
-          // This is for a tcp connection.
-          // const multiaddr = `${thisRelay.multiaddr}/p2p-circuit/p2p/${thisPeer}`
-          // console.log(`multiaddr: ${multiaddr}`)
-
-          // Use a WebRTC circuit relay connection, since this is the focus for
-          // the js-libp2p project and allows establishing of p2p connections.
-          const multiaddr = `${thisRelay.multiaddr}/p2p-circuit/webrtc/p2p/${thisPeer}`
-
-          // Skip the relay if this node is not connected to it.
-          if (thisRelay.connected) {
-            this.adapters.log.statusLog(1, `refreshPeerConnections() connecting to peer with this multiaddr: ${multiaddr}`)
 
             // Attempt to connect to the node through a circuit relay.
             connected = await this.adapters.ipfs.connectToPeer({ multiaddr })
-            // console.log('v2 relay connected: ', connected)
+            // console.log('direct connection connected: ', connected)
 
             // If the connection was successful, break out of the relay loop.
             // Otherwise try to connect through the next relay.
             if (connected.success) {
               this.adapters.log.statusLog(1,
-                `Successfully connected to peer ${thisPeer} through v2 circuit relay ${thisRelay.multiaddr}.`
+                `Successfully connected to peer ${thisPeer} through direct connection: ${multiaddr}.`
               )
 
               // Add the connection multiaddr for this peer to the thisNode object.
@@ -461,14 +407,76 @@ class PeerUseCases {
               // Add the connection multiaddr to the peer, so that we can see
               // exactly how we're connected to the peer.
               // const thisPeerData = this.thisNode.peerData.filter(x => x.from === thisPeer)
+              // thisPeerData[0].data.connectionAddr = multiaddr
               // peerData.data.connectionAddr = multiaddr
 
               // Break out of the loop once we've made a successful connection.
               break
             } else {
               this.adapters.log.statusLog(1,
-                `Failed to connect to peer ${thisPeer} through v2 circuit relay: ${multiaddr}. Reason: ${connected.details}`
+                `Failed to connect to peer ${thisPeer} through direct connection: ${multiaddr}. Reason: ${connected.details}`
               )
+            }
+          }
+        }
+
+        if (connected.success) {
+          continue
+        }
+
+        // Skip this section if the peer has a preference for direct connection.
+        if (connectPref !== 'direct') {
+          // Sort the Circuit Relays by the average of the aboutLatency
+          // array. Connect to peers through the Relays with the lowest latencies
+          // first.
+          const sortedRelays = this.relayUseCases.sortRelays(relays)
+          // console.log(`sortedRelays: ${JSON.stringify(sortedRelays, null, 2)}`)
+
+          // Loop through each known circuit relay and attempt to connect to the
+          // peer through a relay.
+          for (let j = 0; j < sortedRelays.length; j++) {
+            const thisRelay = sortedRelays[j]
+            // console.log(`thisRelay: ${JSON.stringify(thisRelay, null, 2)}`)
+
+            // Generate a multiaddr for connecting to the peer through a circuit relay.
+            // This is for a tcp connection.
+            // const multiaddr = `${thisRelay.multiaddr}/p2p-circuit/p2p/${thisPeer}`
+            // console.log(`multiaddr: ${multiaddr}`)
+
+            // Use a WebRTC circuit relay connection, since this is the focus for
+            // the js-libp2p project and allows establishing of p2p connections.
+            const multiaddr = `${thisRelay.multiaddr}/p2p-circuit/webrtc/p2p/${thisPeer}`
+
+            // Skip the relay if this node is not connected to it.
+            if (thisRelay.connected) {
+              this.adapters.log.statusLog(1, `refreshPeerConnections() connecting to peer with this multiaddr: ${multiaddr}`)
+
+              // Attempt to connect to the node through a circuit relay.
+              connected = await this.adapters.ipfs.connectToPeer({ multiaddr })
+              // console.log('v2 relay connected: ', connected)
+
+              // If the connection was successful, break out of the relay loop.
+              // Otherwise try to connect through the next relay.
+              if (connected.success) {
+                this.adapters.log.statusLog(1,
+                  `Successfully connected to peer ${thisPeer} through v2 circuit relay ${thisRelay.multiaddr}.`
+                )
+
+                // Add the connection multiaddr for this peer to the thisNode object.
+                this.updatePeerConnectionInfo({ thisPeer })
+
+                // Add the connection multiaddr to the peer, so that we can see
+                // exactly how we're connected to the peer.
+                // const thisPeerData = this.thisNode.peerData.filter(x => x.from === thisPeer)
+                // peerData.data.connectionAddr = multiaddr
+
+                // Break out of the loop once we've made a successful connection.
+                break
+              } else {
+                this.adapters.log.statusLog(1,
+                  `Failed to connect to peer ${thisPeer} through v2 circuit relay: ${multiaddr}. Reason: ${connected.details}`
+                )
+              }
             }
           }
         }

--- a/lib/use-cases/schema.js
+++ b/lib/use-cases/schema.js
@@ -14,6 +14,11 @@ class Schema {
       ipfsMultiaddrs: schemaConfig.ipfsMultiaddrs
         ? schemaConfig.ipfsMultiaddrs
         : [],
+
+      // Connection preference. Default is Circuit Relay. Alternative option
+      // is 'direct', which prefers a direct ip4 or ip6 connection.
+      ipfsConnectPref: process.env.CONNECT_PREF ? process.env.CONNECT_PREF : 'cr',
+
       isCircuitRelay: schemaConfig.isCircuitRelay
         ? schemaConfig.isCircuitRelay
         : false,


### PR DESCRIPTION
Added a `CONNECT_PREF` environment variable to the schema library. Peer nodes can specify a connection preference in their announcement object. This will prevent 'server' nodes from connecting via circuit relay, which can prevent file upload.

This feature was inspired by the prototype p2wdb-image-upload project. The p2wdb-image-upload-backend server was connecting to the ipfs-file-pin-service via circuit relay, even though they both had public ip4 addresses. This behavior was preventing the transfer of files between the two nodes.