### PR TITLE
Adding webRTC addrs to announce object

### DIFF
--- a/lib/controllers/timer-controller.js
+++ b/lib/controllers/timer-controller.js
@@ -213,22 +213,32 @@ class TimerControllers {
       // Disable the timer interval while this function executes.
       clearInterval(this.announceTimerHandle)
 
+      // Get multiaddrs that can be used to connect to this node.
+      const multiaddrs = useCases.peer.getMultiaddrs()
+      // console.log('manageAnnouncement(): multiaddrs: ', multiaddrs)
+
       // Get the information needed for the announcement.
       const announceObj = {
         ipfsId: thisNode.ipfsId,
-        ipfsMultiaddrs: thisNode.ipfsMultiaddrs,
+        // ipfsMultiaddrs: thisNode.ipfsMultiaddrs,
+        ipfsMultiaddrs: multiaddrs,
         type: thisNode.type,
         // orbitdbId: thisNode.orbit.id,
 
         // TODO: Allow node.js apps to pass a config setting to override this.
         isCircuitRelay: false
       }
+      // console.log('announceObj: ', announceObj)
 
       // Generate the announcement message.
       const announceMsgObj = thisNode.schema.announcement(announceObj)
       // console.log(`announceMsgObj: ${JSON.stringify(announceMsgObj, null, 2)}`)
 
+      // Overwrite the default multiaddrs with the latest multiaddrs.
+      announceMsgObj.ipfsMultiaddrs = multiaddrs
+
       const announceMsgStr = JSON.stringify(announceMsgObj)
+      console.log('announceMsgStr: ', announceMsgStr)
 
       // Publish the announcement to the pubsub channel.
       await this.adapters.pubsub.messaging.publishToPubsubChannel(

--- a/lib/use-cases/peer-use-cases.js
+++ b/lib/use-cases/peer-use-cases.js
@@ -430,7 +430,7 @@ class PeerUseCases {
         // Skip this section if the peer has a preference for direct connection.
         if (connectPref !== 'direct') {
           // Retrieve the webRTC multiaddrs from the peers announcement object.
-          const filteredMultiaddrs = peerData.data.ipfsMultiaddrs.filter(x => x.includes('/p2p-circuit/webrtc'))
+          const filteredMultiaddrs = peerData.data.ipfsMultiaddrs.filter(x => x.includes('/p2p-circuit/'))
           this.adapters.log.statusLog(1, 'webRTC filteredMultiaddrs: ', filteredMultiaddrs)
 
           // If the peer has no webRTC multiaddrs, then skip this peer

--- a/lib/use-cases/peer-use-cases.js
+++ b/lib/use-cases/peer-use-cases.js
@@ -42,6 +42,8 @@ class PeerUseCases {
     this.sendRPC = this.sendRPC.bind(this)
     this.relayMetricsHandler = this.relayMetricsHandler.bind(this)
     this.getWebRtcMultiaddr = this.getWebRtcMultiaddr.bind(this)
+    this.refreshPeerConnections = this.refreshPeerConnections.bind(this)
+    this.getMultiaddrs = this.getMultiaddrs.bind(this)
 
     // Inject the relayMetricsHandler function into the pubsub adapter.
     this.adapters.pubsub.injectMetricsHandler(this.relayMetricsHandler)
@@ -686,7 +688,7 @@ class PeerUseCases {
   // Add them to the announcement object.
   getWebRtcMultiaddr (inObj = {}) {
     try {
-      console.log('---->Entering getWebRtcMultiaddr() Use Case.<----')
+      // console.log('---->Entering getWebRtcMultiaddr() Use Case.<----')
 
       const { thisNode } = inObj
 
@@ -694,7 +696,7 @@ class PeerUseCases {
       const addrs = this.adapters.ipfs.ipfs.libp2p.getMultiaddrs()
 
       const webRtcAddrs = addrs.filter(x => WebRTC.matches(x))
-      console.log('webRTC addrs: ', webRtcAddrs)
+      // console.log('webRTC addrs: ', webRtcAddrs)
 
       // If there are any webRTC multiaddrs, add them to the announcement object.
       if (webRtcAddrs.length) {
@@ -709,13 +711,46 @@ class PeerUseCases {
 
         // Add the new webRTC multiaddrs to the announcement object.
         thisNode.ipfsMultiaddrs = noRtcAddrs
-        console.log(`Updated thisNode.ipfsMultiaddrs: ${JSON.stringify(thisNode.ipfsMultiaddrs, null, 2)}`)
+        // console.log(`Updated thisNode.ipfsMultiaddrs: ${JSON.stringify(thisNode.ipfsMultiaddrs, null, 2)}`)
       }
 
       // return webRtcAddrs
     } catch (err) {
       console.error('Error in peer-use-cases.js/getWebRtcMultiaddr(): ', err)
       return false
+    }
+  }
+
+  // This function expects an array of multiaddrs. It removes any elements
+  // that contain /p2p-circuit/webrtc, retrieves any webRTC multiaddrs from
+  // the node, adds them to the array, and returns the updated array.
+  // This information is then used in the announcement object, to let other
+  // nodes know how to connect to this node using webRTC.
+  getMultiaddrs (inObj = {}) {
+    try {
+      // Get multiaddrs that can be used to connect to this node.
+      const addrs = this.adapters.ipfs.ipfs.libp2p.getMultiaddrs()
+      // console.log('addrs: ', addrs)
+
+      const addrStrs = addrs.map(x => x.toString())
+      // console.log('addrStrs: ', addrStrs)
+
+      // Filter out multiaddrs with a low chance of success
+      const filteredAddrs = addrStrs.filter(x => {
+        if (x.includes('127.0.0.1')) return false
+        if (x.includes('udp')) return false
+        if (x.includes('quic')) return false
+        if (x.includes('192.168.')) return false
+        if (x.includes('172.1') || x.includes('172.2') || x.includes('172.3')) return false
+        if (x.includes('/10.')) return false
+        return true
+      })
+      // console.log('filteredAddrs: ', filteredAddrs)
+
+      return filteredAddrs
+    } catch (err) {
+      console.error('Error in getMultiaddrs(): ', err)
+      return []
     }
   }
 }

--- a/test/mocks/use-case-mocks.js
+++ b/test/mocks/use-case-mocks.js
@@ -22,7 +22,8 @@ class UseCasesMock {
     }
     this.peer = {
       addSubnetPeer: async () => {},
-      refreshPeerConnections: async () => {}
+      refreshPeerConnections: async () => {},
+      getMultiaddrs: async () => {}
     }
   }
 }


### PR DESCRIPTION
This change detects the webRTC and circuit relay multiaddrs from the Helia node, and publishes those addresses to the announcement object. This allows other peers to connect to them via those multiaddrs.